### PR TITLE
fix: correct info_hash decoding in BitTorrent announce endpoint

### DIFF
--- a/.env
+++ b/.env
@@ -3,7 +3,7 @@ DATABASE_URL="postgresql://nexustracker_user:nexustracker_password@localhost:543
 
 # NextAuth
 NEXTAUTH_SECRET="tu-super-secreto-muy-seguro-aqui-cambialo-en-produccion"
-NEXTAUTH_URL="http://localhost:3000"
+NEXTAUTH_URL="http://192.168.1.54:3000"
 
 # Environment
 NODE_ENV="development"


### PR DESCRIPTION
- Add percentDecodeToBuffer function to properly decode percent-encoded info_hash
- Extract info_hash directly from URL string to avoid automatic UTF-8 decoding
- Fix torrent lookup by using decoded hexadecimal hash
- Ensure compatibility with qBittorrent and other BitTorrent clients